### PR TITLE
update docker image and increase concurrent connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,19 @@ RUN cargo install wasm-pack
 WORKDIR /build
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-#    --mount=type=cache,target=/build/target \
+    #    --mount=type=cache,target=/build/target \
     cd ./volts-front && \
     wasm-pack build --target web && \
     cd .. && \
     cargo build --bin volts-server --release
 
 # Runtime image
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update
-RUN apt-get -y install postgresql-client-13
+RUN apt install -y postgresql-common
+RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -i -v 14
+RUN apt-get -y install postgresql-client-14
 RUN apt-get -y install nginx
 RUN apt-get install ca-certificates -y
 RUN update-ca-certificates

--- a/fly.toml
+++ b/fly.toml
@@ -19,8 +19,8 @@ processes = []
   script_checks = []
   
   [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
+    hard_limit = 100
+    soft_limit = 25
     type = "connections"
 
   [[services.ports]]


### PR DESCRIPTION
- Updated Debian image since `bullseye` has only OpenSSL 1.1.1, `bookworm` is using OpenSSL 3
- Added PostgreSQL repository installation since Debian doesn't ship PostgreSQL 14 anymore
- Increased connection concurrency limit, I think the app and machine should handle it fine